### PR TITLE
Change the default analyzer to cjk

### DIFF
--- a/schema/answers.js
+++ b/schema/answers.js
@@ -3,7 +3,7 @@ export default {
   properties: {
     versions: {
       properties: {
-        text: {type: 'text'},
+        text: {type: 'text', analyzer: 'cjk'},
         reference: {type: 'text'},
         createdAt: { type: 'date' },
       }

--- a/schema/rumors.js
+++ b/schema/rumors.js
@@ -2,7 +2,7 @@ export default {
   _all: {enabled: false},
   properties: {
     answerIds: { type: 'keyword', },
-    text: { type: 'text', },
+    text: { type: 'text', analyzer: 'cjk'},
     tags: {type: 'keyword'},
     createdAt: { type: 'date' },
     updatedAt: { type: 'date' }


### PR DESCRIPTION
需搭配 MrOrz/rumors-api#20 使用。

選 CJK analyzer 基本上就只是為了改用 bigram，我目前沒看到其他適用繁體中文的 analyzer。
[ICU analyzer](https://www.elastic.co/guide/en/elasticsearch/plugins/5.1/analysis-icu.html) 或許效果會更好，但版本升級時可能不會向前相容。