### PR TITLE
recognize url, email as single token

### DIFF
--- a/db/loadSchema.js
+++ b/db/loadSchema.js
@@ -13,7 +13,30 @@ Object.keys(schema).forEach((index) => {
   client.indices.create({
     index,
     body: {
-      settings: { number_of_shards: 1 },
+      settings: {
+        number_of_shards: 1,
+        index: {
+          analysis: {
+            filter: {
+              english_stop: {
+                type: "stop",
+                stopwords: "_english_"
+              }
+            },
+            analyzer: {
+              cjk_url_email: {
+                tokenizer: "uax_url_email",
+                filter: [
+                  "cjk_width",
+                  "lowercase",
+                  "cjk_bigram",
+                  "english_stop"
+                ]
+              }
+            }
+          }
+        }
+      },
       mappings: { basic: schema[index] },
     },
   }).then(() => {

--- a/schema/articles.js
+++ b/schema/articles.js
@@ -4,7 +4,7 @@ export default {
     replyIds: { type: 'keyword' },
     replyRequestIds: { type: 'keyword' },
 
-    text: { type: 'text', analyzer: 'cjk' },
+    text: { type: 'text', analyzer: 'cjk_url_email' },
     createdAt: { type: 'date' },
     updatedAt: { type: 'date' },
 

--- a/schema/replies.js
+++ b/schema/replies.js
@@ -4,7 +4,7 @@ export default {
     versions: {
       properties: {
         type: { type: 'keyword' }, // 'RUMOR', 'NOT_RUMOR', 'NOT_ARTICLE'
-        text: { type: 'text', analyzer: 'cjk' },
+        text: { type: 'text', analyzer: 'cjk_url_email' },
         reference: { type: 'text' },
         createdAt: { type: 'date' },
       },


### PR DESCRIPTION
修改原本使用的 cjk analyzer 搭配 uax_url_email tokenizer.

原本 standard tokenizer 會將 url 的 host 跟 path 拆開, 
導致原本文章內同個網站的不同網址 也會被搜尋出來,

將 url 會被視為一個 token, 
則 只有一模一樣的 url 會被搜尋出來.

false positive 會降為 0,
但是 false nagative 則增加三個

```
NOT FOUND] 5362008438138-rumor ------
"http://www.epochtimes.com/b5/16/11/26/n8529299...
Search result:
     #1 (score=7.6084285 / id=5362008438138-rumor) "http://www.epochtimes...

[NOT FOUND] 5420881488132-rumor ------
"http://www.how01.com/post_12301.html"
Search result:
     #1 (score=7.6084285 / id=5420881488132-rumor) "http://www.how01.com/…

[NOT FOUND] 5449302371652-rumor ------
"https://www.evernote.com/shard/s252/sh/74f237b...
Search result:
     #1 (score=7.6084285 / id=5449302371652-rumor) "https://www.evernote….
```

建議這種 url exact match 的情形要視為特例處理.