### PR TITLE
Add omitted fields

### DIFF
--- a/db/migrations/201712-001-reindex.js
+++ b/db/migrations/201712-001-reindex.js
@@ -180,7 +180,7 @@ async function main() {
     }
   );
 
-  const articleIdToConnections = {};
+  const articleIdToArticleReplies = {};
   const feedbackIdToReplyId = {};
   const feedbackIdToArticleId = {};
   const replyMap = createIdToSourceMap(await fetchAllDocs('replies_legacy'));
@@ -208,11 +208,11 @@ async function main() {
         feedbackId => feedbackIdToScore[feedbackId]
       );
 
-      if (!articleIdToConnections[articleId]) {
-        articleIdToConnections[articleId] = [];
+      if (!articleIdToArticleReplies[articleId]) {
+        articleIdToArticleReplies[articleId] = [];
       }
 
-      articleIdToConnections[articleId].push({
+      articleIdToArticleReplies[articleId].push({
         replyId,
         userId,
         appId: from,
@@ -238,7 +238,24 @@ async function main() {
   //
 
   const operations = [];
-  Object.keys(articleIdToConnections).forEach(articleId => {
+  Object.keys(articleIdToArticleReplies).forEach(articleId => {
+    const articleReplies = articleIdToArticleReplies[articleId];
+    operations.push({
+      update: {
+        _index: getIndexName('articles'),
+        _type: 'doc',
+        _id: articleId,
+      },
+    });
+    operations.push({
+      doc: {
+        articleReplies,
+        normalArticleReplyCount: articleReplies.filter(
+          ({ status }) => status === 'NORMAL'
+        ).length,
+      },
+    });
+  });
     operations.push({
       update: {
         _index: getIndexName('articles'),

--- a/db/migrations/201712-001-reindex.js
+++ b/db/migrations/201712-001-reindex.js
@@ -180,7 +180,7 @@ async function main() {
           const { createdAt } = replyRequestMap[replyRequestId];
           return lastDate > createdAt ? lastDate : createdAt;
         },
-        '1900-01-01T00:00:00.000Z'
+        new Date(0)
       );
     }
   );

--- a/schema/articles.js
+++ b/schema/articles.js
@@ -51,6 +51,10 @@ export default {
       },
     },
 
+    // Cached counts of articleReplies with status = NORMAL.
+    // The length of nested objects cannot be used in filters...
+    normalArticleReplyCount: { type: 'long' },
+
     // Cached counter and timestamp from replyrequests
     replyRequestCount: { type: 'long' },
     lastRequestedAt: { type: 'date' },


### PR DESCRIPTION
1. Add `normalArticleReplyCount` so that we can list articles by number of replies.
I failed to find a way to filter by nested object count, and there are others [suggesting adding such field](https://stackoverflow.com/questions/40721935/filter-to-get-documents-where-the-length-of-a-nested-document-matches-a-number/40726639#40726639) for efficiency, hence I'm adding this field.

2. Correctly implement `lastRequestedAt`, whose initialization is omitted in previous PR.