### PR TITLE
Add fields required for reply request reason & voting reason

### DIFF
--- a/schema/replyrequests.js
+++ b/schema/replyrequests.js
@@ -14,6 +14,27 @@ export default {
     // Should be one of backend APP ID, 'BOT_LEGACY', 'RUMORS_LINE_BOT' or 'WEBSITE'
     appId: { type: 'keyword' },
 
+    // Why the ReplyRequest is created
+    reason: { type: 'text', analyzer: 'cjk_url_email' },
+
+    // Editor's feedbacks for the reply request's reason
+    feedbacks: {
+      type: 'nested',
+      properties: {
+        // Auth
+        userId: { type: 'keyword' },
+        appId: { type: 'keyword' },
+
+        score: { type: 'byte' }, // 1, 0, -1
+        createdAt: { type: 'date' },
+        updatedAt: { type: 'date' },
+      },
+    },
+
+    // Counter cache for feedbacks
+    positiveFeedbackCount: { type: 'long' },
+    negativeFeedbackCount: { type: 'long' },
+
     createdAt: { type: 'date' },
     updatedAt: { type: 'date' },
   },


### PR DESCRIPTION
In order to implement https://github.com/cofacts/rumors-api/issues/67 , we should add these fields to DB.

Existing reply request does not have reason fields. They can't be given feedbacks anyway, thus I think we don't need to migrate them.