### PR TITLE
Add automatic reindex script

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,19 @@ $ docker-compose up
 This spins up elasticsearch on `localhost:62223`, with Kibana available in `localhost:62224`, using
 the data in `esdata`.
 
+## Updating schema
+
+After adding fields / removing fields from indices, you will need to reload schema because
+elasticsearch mappings are not editable for opened indices.
+
+This can be done by:
+
+1. Manually bumping the schema version in package.json
+2. Run `npm run reload`
+
+The `npm run reload` would create indices with latest schema & package.json version postfix,
+perform reindex, modifies alias and removes all old indices.
+
 ---
 
 ## Other commands

--- a/db/loadSchema.js
+++ b/db/loadSchema.js
@@ -4,6 +4,7 @@ import config from 'config';
 import elasticsearch from 'elasticsearch';
 import '../util/catchUnhandledRejection';
 import getIndexName from '../util/getIndexName';
+import indexSetting from '../util/indexSetting';
 
 import * as schema from '../schema';
 
@@ -19,30 +20,7 @@ Object.keys(schema).forEach(index => {
     .create({
       index: indexName,
       body: {
-        settings: {
-          number_of_shards: 1,
-          index: {
-            analysis: {
-              filter: {
-                english_stop: {
-                  type: 'stop',
-                  stopwords: '_english_',
-                },
-              },
-              analyzer: {
-                cjk_url_email: {
-                  tokenizer: 'uax_url_email',
-                  filter: [
-                    'cjk_width',
-                    'lowercase',
-                    'cjk_bigram',
-                    'english_stop',
-                  ],
-                },
-              },
-            },
-          },
-        },
+        settings: indexSetting,
         mappings: { doc: schema[index] },
         aliases: {
           [index]: {},

--- a/db/reloadSchema.js
+++ b/db/reloadSchema.js
@@ -17,6 +17,9 @@ const aliasNames = Object.keys(schema);
 
 let aliasToOldIndexMap = {};
 
+/**
+ * @returns {Promise<undefined>}
+ */
 async function populateOldIndexMap() {
   // Returns:
   // { replies_v1_0_0: { aliases: { replies: {} } },
@@ -59,7 +62,7 @@ async function populateOldIndexMap() {
 }
 
 /**
- * @returns <Promise>
+ * @returns {Promise<object[]>}
  */
 function createNewIndexes() {
   return Promise.all(
@@ -92,6 +95,9 @@ function createNewIndexes() {
   );
 }
 
+/**
+ * @returns {Promise<object[]>}
+ */
 function reindexExistingIndexes() {
   return Promise.all(
     aliasNames.map(alias => {
@@ -118,8 +124,10 @@ function reindexExistingIndexes() {
  * Switch alias to new index and remove old indexes in one go.
  *
  * Reference: https://www.elastic.co/guide/en/elasticsearch/reference/6.2/indices-aliases.html
+ *
+ * @returns {Promise<object>}
  */
-async function switchAndRemoveAllAliases() {
+function switchAndRemoveAllAliases() {
   const actions = aliasNames.reduce((actions, alias) => {
     const newActions = [
       {
@@ -135,9 +143,12 @@ async function switchAndRemoveAllAliases() {
     return actions.concat(newActions);
   }, []);
 
-  client.indices.updateAliases({ body: { actions } });
+  return client.indices.updateAliases({ body: { actions } });
 }
 
+/**
+ * Main script
+ */
 Promise.resolve()
   .then(populateOldIndexMap)
   .then(createNewIndexes)

--- a/db/reloadSchema.js
+++ b/db/reloadSchema.js
@@ -1,0 +1,145 @@
+/*eslint import/namespace: ['error', { allowComputed: true }]*/
+
+import config from 'config';
+import elasticsearch from 'elasticsearch';
+import '../util/catchUnhandledRejection';
+import getIndexName from '../util/getIndexName';
+import indexSetting from '../util/indexSetting';
+
+import * as schema from '../schema';
+
+const client = new elasticsearch.Client({
+  host: config.get('ELASTICSEARCH_URL'),
+  log: 'trace',
+});
+
+const aliasNames = Object.keys(schema);
+
+let aliasToOldIndexMap = {};
+
+async function populateOldIndexMap() {
+  // Returns:
+  // { replies_v1_0_0: { aliases: { replies: {} } },
+  //   articles_v1_0_0: { aliases: { articles: {} } }, ... }
+
+  const { error, status, ...currentIndexAliasMappings } = await client.indices
+    .getAlias({
+      name: aliasNames,
+      ignoreUnavailable: true, // some aliasNames may be new
+    })
+    .catch(e => {
+      if (!e.body) throw e;
+
+      return e.body;
+    });
+
+  console.info('[INFO] Error:', error, `status: ${status}`);
+
+  aliasToOldIndexMap = Object.keys(currentIndexAliasMappings).reduce(
+    (map, realIndexName) => {
+      const alias = Object.keys(
+        currentIndexAliasMappings[realIndexName].aliases
+      )[0];
+      map[alias] = realIndexName;
+      return map;
+    },
+    {}
+  );
+
+  // Check if any new index name will collide with existing old indexes.
+  // If so, abort operation.
+  aliasNames.forEach(alias => {
+    const newIndexName = getIndexName(alias);
+    if (currentIndexAliasMappings[newIndexName]) {
+      throw new Error(
+        `${newIndexName} already exists in current DB, abort operation.\nPlease bump version in package.json.`
+      );
+    }
+  });
+}
+
+/**
+ * @returns <Promise>
+ */
+function createNewIndexes() {
+  return Promise.all(
+    aliasNames.map(alias => {
+      const indexName = getIndexName(alias);
+
+      return client.indices
+        .create({
+          index: indexName,
+          body: {
+            settings: indexSetting,
+            mappings: { doc: schema[alias] },
+          },
+        })
+        .catch(e => {
+          // Ignore already-exist errors.
+          // They might be error in previous runs, and they are not linked with alias yet.
+          if (
+            e.body &&
+            e.body.error.type === 'resource_already_exists_exception'
+          )
+            return;
+
+          throw e;
+        })
+        .then(() => {
+          console.log(`Index "${alias}" created with mappings`);
+        });
+    })
+  );
+}
+
+function reindexExistingIndexes() {
+  return Promise.all(
+    aliasNames.map(alias => {
+      const oldIndexName = aliasToOldIndexMap[alias];
+      if (!oldIndexName) return; // new alias that does not exist in DB
+
+      return client.reindex({
+        waitForCompletion: true,
+        body: {
+          source: { index: oldIndexName },
+          dest: {
+            index: getIndexName(alias),
+            type: 'doc',
+            op_type: 'create',
+          },
+          conflicts: 'proceed',
+        },
+      });
+    })
+  );
+}
+
+/**
+ * Switch alias to new index and remove old indexes in one go.
+ *
+ * Reference: https://www.elastic.co/guide/en/elasticsearch/reference/6.2/indices-aliases.html
+ */
+async function switchAndRemoveAllAliases() {
+  const actions = aliasNames.reduce((actions, alias) => {
+    const newActions = [
+      {
+        add: { index: getIndexName(alias), alias },
+      },
+    ];
+    const oldIndexName = aliasToOldIndexMap[alias];
+    if (oldIndexName)
+      newActions.push({
+        remove_index: { index: oldIndexName },
+      });
+
+    return actions.concat(newActions);
+  }, []);
+
+  client.indices.updateAliases({ body: { actions } });
+}
+
+Promise.resolve()
+  .then(populateOldIndexMap)
+  .then(createNewIndexes)
+  .then(reindexExistingIndexes)
+  .then(switchAndRemoveAllAliases);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rumors-db",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Cofacts Database schema & scripts",
   "main": "index.js",
   "license": "MIT",
@@ -8,6 +8,7 @@
     "lint": "eslint .",
     "lint:fix": "eslint --fix .",
     "schema": "babel-node db/loadSchema.js",
+    "reload": "babel-node db/reloadSchema.js",
     "clear": "babel-node db/clear.js",
     "test": "NODE_ENV=test npm run clear && NODE_ENV=test npm run schema"
   },

--- a/util/getIndexName.js
+++ b/util/getIndexName.js
@@ -1,5 +1,11 @@
 import { version } from '../package.json';
 
+/**
+ * Generates the real index name with version from package.json
+ *
+ * @param {string} index - name of the Elasticsearch index
+ * @returns {string} The real index name with version postfix
+ */
 export default function getIndexName(index) {
   return `${index}_v${version.replace(/\./g, '_')}`;
 }

--- a/util/indexSetting.js
+++ b/util/indexSetting.js
@@ -1,0 +1,19 @@
+export default {
+  number_of_shards: 1,
+  index: {
+    analysis: {
+      filter: {
+        english_stop: {
+          type: 'stop',
+          stopwords: '_english_',
+        },
+      },
+      analyzer: {
+        cjk_url_email: {
+          tokenizer: 'uax_url_email',
+          filter: ['cjk_width', 'lowercase', 'cjk_bigram', 'english_stop'],
+        },
+      },
+    },
+  },
+};


### PR DESCRIPTION
Adds `npm run reload`, which automatically reindex to new schema, re-route the alias and deletes old schema.