### PR TITLE
Disables index & sorting for urls' "html" field

### DIFF
--- a/schema/urls.js
+++ b/schema/urls.js
@@ -4,7 +4,10 @@ export default {
     canonical: { type: 'keyword' }, // The canonical URL fetched from the page
     title: { type: 'text', analyzer: 'cjk' },
     summary: { type: 'text', analyzer: 'cjk' }, // Extracted summary text
-    html: { type: 'keyword' }, // Fetched raw html input
+    html: { type: 'keyword', index: false, doc_values: false }, // Fetched raw html input.
+    // We disables html's indexing and doc_values because html would be super long and cause
+    // "DocValuesField is too large" error when indexed or sorted.
+
     topImageUrl: { type: 'keyword' }, // Image URL for preview
 
     fetchedAt: { type: 'date' },

--- a/schema/urls.js
+++ b/schema/urls.js
@@ -11,5 +11,6 @@ export default {
     topImageUrl: { type: 'keyword' }, // Image URL for preview
 
     fetchedAt: { type: 'date' },
+    status: { type: 'short' }, // status code of the response
   },
 };


### PR DESCRIPTION
Currently when we are writing HTML scrapped from the internet to `urls` index, we are getting these errors:
- https://stackoverflow.com/questions/24019868/utf8-encoding-is-longer-than-the-max-length-32766
- https://github.com/Stratio/cassandra-lucene-index/issues/13

SInce `urls`'s `html` won't participate in searching, it's just a cached field that may be used when we improve summary extraction, we should turn off indexing and sorting (`doc_values: false`) for this field to avoid the errors above.