### PR TITLE
Add comment field to articlereplyfeedbacks

### DIFF
--- a/schema/articlereplyfeedbacks.js
+++ b/schema/articlereplyfeedbacks.js
@@ -11,6 +11,8 @@ export default {
     appId: { type: 'keyword' },
 
     score: { type: 'byte' }, // 1, 0, -1
+    comment: { type: 'text', analyzer: 'cjk_url_email' }, // user comment for the article reply
+
     createdAt: { type: 'date' },
     updatedAt: { type: 'date' },
   },


### PR DESCRIPTION
The API supports [writing comment to article reply feedbacks](https://github.com/cofacts/rumors-api/blob/master/src/graphql/mutations/CreateOrUpdateArticleReplyFeedback.js#L63), and the LINE bot [do accepts comments](https://github.com/cofacts/rumors-line-bot/pull/85), but actually the `comment` field is not in schema until this PR 😂 