### PR TITLE
Apply no-op and log results in migration 202005

### DIFF
--- a/db/migrations/202005-add-article-categories.js
+++ b/db/migrations/202005-add-article-categories.js
@@ -27,12 +27,15 @@ async function addArticleCategory() {
           source: `
             if (ctx._source.articleCategories === null) {
               ctx._source.articleCategories = new ArrayList();
+            } else {
+              ctx.op = 'noop';
             }
           `,
         },
       },
     })
-    .catch(e => console.error(e));
+    .then(resp => console.log(resp))
+    .catch(e => console.error(JSON.stringify(e, null, '  ')));
 }
 
 async function main() {


### PR DESCRIPTION
This PR improves #40 by:
- tells elasticsearch to do nothing when `articleCategories` exists
- log everything when error occurs
- log response when success

![image](https://user-images.githubusercontent.com/108608/81495709-be3ba480-92e4-11ea-8c40-998f767ec0b9.png)
