### PR TITLE
Reload individual file and adjust mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@ For development, copy `.env.sample` to `.env` and make necessary changes.
 
 All mappings exist in `schema/` directory, with `schema/index.js` being the entry point.
 
-When loading tschema into DB using `npm run schema`, it appends `_vX_Y_Z` in the created indecies,
+When loading tschema into DB using `npm run schema`, it appends `_vX.U.Z` in the created indecies,
 
-then create an alias to the index name, in which `X.Y.Z` is the version name in `package.json`.
+then create an alias to the index name, according to `VERSION` const in the respective version file.
 
 For example, the mappings in `schema/articles.js` would go to the index `articles_v1_0_0` and an
 alias from `articles` to `articles_v1_0_0` would be created after running `npm run schema`, given
-that the `version` in `package.json` is `1.0.0`.
+that the `VERSION` in `schema/article.js` is `1.0.0`.
 
 ## Running migrations
 
@@ -62,18 +62,18 @@ $ docker-compose up
 This spins up elasticsearch on `localhost:62223`, with Kibana available in `localhost:62224`, using
 the data in `esdata`.
 
-## Updating schema
+## Updating schema for one index
 
-After adding fields / removing fields from indices, you will need to reload schema because
+After adding fields / removing fields from an index file, you will need to reload schema because
 elasticsearch mappings are not editable for opened indices.
 
 This can be done by:
 
-1. Manually bumping the schema version in package.json
-2. Run `npm run reload`
+1. Manually bumping the schema version in the schema file
+2. Run `npm run reload <index file name>` (For instance, `npm run reload replyrequests`)
 
 The `npm run reload` would create indices with latest schema & package.json version postfix,
-perform reindex, modifies alias and removes all old indices.
+perform reindex, modifies alias and removes the old index.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ For development, copy `.env.sample` to `.env` and make necessary changes.
 
 All mappings exist in `schema/` directory, with `schema/index.js` being the entry point.
 
-When loading tschema into DB using `npm run schema`, it appends `_vX.U.Z` in the created indecies,
+When loading tschema into DB using `npm run schema`, it appends `_${VERSION}` in the created indecies,
 
-then create an alias to the index name, according to `VERSION` const in the respective version file.
+then create an alias to the index name, according to `VERSION` const in the respective schema file.
 
 For example, the mappings in `schema/articles.js` would go to the index `articles_v1_0_0` and an
 alias from `articles` to `articles_v1_0_0` would be created after running `npm run schema`, given

--- a/README.md
+++ b/README.md
@@ -70,9 +70,9 @@ elasticsearch mappings are not editable for opened indices.
 This can be done by:
 
 1. Manually bumping the schema version in the schema file
-2. Run `npm run reload <index file name>` (For instance, `npm run reload replyrequests`)
+2. Run `npm run reload -- <index file name>` (For instance, `npm run reload -- replyrequests`)
 
-The `npm run reload` would create indices with latest schema & package.json version postfix,
+The script would create indices with latest schema & package.json version postfix,
 perform reindex, modifies alias and removes the old index.
 
 ---

--- a/README.md
+++ b/README.md
@@ -85,9 +85,14 @@ These commands are invoked by commands mentioned above. See `package.json` for d
 
 Deletes all indices.
 
-### `npm run schema`
+### `npm run schema [-- indexName]`
 
 Creates indices with specified mappings.
+
+By default it will create all indexes that exists in `schema/` directory, and will error if the index
+already exists.
+
+We can create one index by specifying `indexName` in the command.
 
 ### `npm run seed`
 

--- a/db/loadSchema.js
+++ b/db/loadSchema.js
@@ -26,10 +26,10 @@ async function loadSchema() {
         },
       });
     } catch (e) {
-      console.error(`Error creating index "${index}"`, e);
+      console.error(`Error creating index "${indexName}"`, e);
       throw e;
     }
-    console.log(`Index "${index}" created with mappings`);
+    console.log(`Index "${indexName}" created with mappings`);
   }
 }
 

--- a/db/loadSchema.js
+++ b/db/loadSchema.js
@@ -11,8 +11,19 @@ const client = new elasticsearch.Client({
   node: process.env.ELASTICSEARCH_URL,
 });
 
+const INDEX_NAME = process.argv[2];
+
+if (INDEX_NAME && !schema[INDEX_NAME]) {
+  console.error(
+    `Specified index ${INDEX_NAME} is not exported in schema/index.js.`
+  );
+  process.exit(1);
+}
+
+const SCHEMA_NAMES = INDEX_NAME ? [INDEX_NAME] : Object.keys(schema);
+
 async function loadSchema() {
-  for (const index of Object.keys(schema)) {
+  for (const index of SCHEMA_NAMES) {
     const indexName = getIndexName(index);
     try {
       await client.indices.create({

--- a/db/reloadSchema.js
+++ b/db/reloadSchema.js
@@ -7,7 +7,7 @@ import indexSetting from '../util/indexSetting';
 
 const client = new elasticsearch.Client({
   node: process.env.ELASTICSEARCH_URL,
-  requestTimeout: 300000, // 5 min
+  requestTimeout: 30 * 60 * 1000, // 30 min
 });
 
 const INDEX_NAME = process.argv[2];

--- a/db/reloadSchema.js
+++ b/db/reloadSchema.js
@@ -24,7 +24,7 @@ try {
     __dirname,
     `../schema/${INDEX_NAME}.js`
   ));
-  INDEX_MAPPING = indexMapping;
+  INDEX_MAPPING = indexMapping.default;
 } catch (e) {
   if (e.code === 'MODULE_NOT_FOUND') {
     console.error(`There is no "${INDEX_NAME}.js" under schema directory.`);
@@ -126,9 +126,9 @@ async function main() {
     createResult.index
   );
   console.log(
-    `Reindexed from ${existingAlias} to ${createResult.index} in ${
-      reindexResult.took
-    } milliseconds.`
+    `Reindexed from ${existingAlias} to ${createResult.index} in ${Math.round(
+      reindexResult.took / 1000
+    )} seconds.`
   );
 
   await switchAndRemoveOldAlias(existingAlias);

--- a/schema/analytics.js
+++ b/schema/analytics.js
@@ -1,3 +1,5 @@
+export const VERSION = '1.1.0';
+
 export default {
   properties: {
     date: { type: 'date' },

--- a/schema/app.js
+++ b/schema/app.js
@@ -1,3 +1,5 @@
+export const VERSION = '1.1.0';
+
 export default {
   _all: { enabled: false },
   properties: {

--- a/schema/articlecategoryfeedbacks.js
+++ b/schema/articlecategoryfeedbacks.js
@@ -1,3 +1,5 @@
+export const VERSION = '1.1.0';
+
 export default {
   properties: {
     articleId: { type: 'keyword' },

--- a/schema/articlereplyfeedbacks.js
+++ b/schema/articlereplyfeedbacks.js
@@ -1,3 +1,5 @@
+export const VERSION = '1.1.0';
+
 export default {
   properties: {
     // // The article ID and reply ID is used in calculating replyrequests' ID.

--- a/schema/articles.js
+++ b/schema/articles.js
@@ -1,3 +1,5 @@
+export const VERSION = '1.1.0';
+
 export default {
   properties: {
     text: { type: 'text', analyzer: 'cjk_url_email' },

--- a/schema/articles.js
+++ b/schema/articles.js
@@ -69,7 +69,7 @@ export default {
         url: { type: 'keyword' }, // exact URL found in the articles
         normalizedUrl: { type: 'keyword' }, // URL after normalization (stored in urls)
         title: { type: 'text', analyzer: 'cjk' },
-        summary: { type: 'text', analyzer: 'cjk' }, // Extracted summary text
+        summary: { type: 'text', analyzer: 'cjk_url_email' }, // Extracted summary text
       },
     },
 

--- a/schema/categories.js
+++ b/schema/categories.js
@@ -1,3 +1,5 @@
+export const VERSION = '1.1.0';
+
 export default {
   properties: {
     title: { type: 'text', analyzer: 'cjk' },

--- a/schema/replies.js
+++ b/schema/replies.js
@@ -1,3 +1,5 @@
+export const VERSION = '1.1.0';
+
 export default {
   properties: {
     userId: { type: 'keyword' },
@@ -5,7 +7,7 @@ export default {
 
     type: { type: 'keyword' }, // 'RUMOR', 'NOT_RUMOR', 'OPINIONATED', 'NOT_ARTICLE'
     text: { type: 'text', analyzer: 'cjk_url_email' },
-    reference: { type: 'text' },
+    reference: { type: 'text', analyzer: 'cjk_url_email' },
     createdAt: { type: 'date' },
 
     // Links in the text & reference

--- a/schema/replies.js
+++ b/schema/replies.js
@@ -16,7 +16,7 @@ export default {
       properties: {
         url: { type: 'keyword' }, // exact URL found in the articles
         title: { type: 'text', analyzer: 'cjk' },
-        summary: { type: 'text', analyzer: 'cjk' }, // Extracted summary text
+        summary: { type: 'text', analyzer: 'cjk_url_email' }, // Extracted summary text
       },
     },
   },

--- a/schema/replyrequests.js
+++ b/schema/replyrequests.js
@@ -1,3 +1,5 @@
+export const VERSION = '1.1.0';
+
 // A request from users for an article to be replied.
 // (articleId, userId, appId) should be unique throughout DB.
 //

--- a/schema/urls.js
+++ b/schema/urls.js
@@ -1,3 +1,5 @@
+export const VERSION = '1.1.0';
+
 export default {
   properties: {
     url: { type: 'keyword' }, // exact URL found in the articles

--- a/schema/urls.js
+++ b/schema/urls.js
@@ -5,7 +5,7 @@ export default {
     url: { type: 'keyword' }, // exact URL found in the articles
     canonical: { type: 'keyword' }, // The canonical URL fetched from the page
     title: { type: 'text', analyzer: 'cjk' },
-    summary: { type: 'text', analyzer: 'cjk' }, // Extracted summary text
+    summary: { type: 'text', analyzer: 'cjk_url_email' }, // Extracted summary text
     html: { type: 'keyword', index: false, doc_values: false }, // Fetched raw html input.
     // We disables html's indexing and doc_values because html would be super long and cause
     // "DocValuesField is too large" error when indexed or sorted.

--- a/schema/users.js
+++ b/schema/users.js
@@ -6,7 +6,7 @@ export default {
     name: { type: 'keyword' },
     avatarUrl: { type: 'keyword' },
     slug: { type: 'keyword' },
-    bio: { type: 'text' },
+    bio: { type: 'text', analyzer: 'cjk_url_email' },
 
     avatarType: { type: 'keyword' }, // AvatarTypeEnum: OpenPeeps/Gravatar/Facebook/Github
     avatarData: {

--- a/schema/users.js
+++ b/schema/users.js
@@ -1,3 +1,5 @@
+export const VERSION = '1.1.0';
+
 export default {
   properties: {
     email: { type: 'keyword' },

--- a/util/getIndexName.js
+++ b/util/getIndexName.js
@@ -1,5 +1,3 @@
-import { version } from '../package.json';
-
 /**
  * Generates the real index name with version from package.json
  *
@@ -7,5 +5,6 @@ import { version } from '../package.json';
  * @returns {string} The real index name with version postfix
  */
 export default function getIndexName(index) {
-  return `${index}_v${version.replace(/\./g, '_')}`;
+  const { VERSION } = require(`../schema/${index}.js`);
+  return `${index}_v${VERSION.replace(/\./g, '_')}`;
 }


### PR DESCRIPTION
This PR enables us to reload one DB index and leave all other indexes intact.
After this PR is pushed to production, we can perform fix on cofacts/rumors-site#399 and cofacts/rumors-site#386

- `npm run schema` now supports optional argument that loads a specified index mapping 
![圖片](https://user-images.githubusercontent.com/108608/112743646-aee04b00-8fcb-11eb-9c43-022643f98a46.png)
    - We also print the full index name (including version postfix) in console logs to make operations more clear.
- `npm run reload` now only reloads the specified index 
![圖片](https://user-images.githubusercontent.com/108608/112743775-d2f05c00-8fcc-11eb-9729-8bd830fa2c12.png)

- `VERSION` const is added and exported in each index mapping files
    - All index versions are bumped to `1.1.0` in this PR.
    - Each index can be versioned separately, which gives more flexibility when we change mappings in the future.
- Change analyzer to support English, Chinese & URL mix for `hyperlinks`' `summary` field and `users`' bio field

