### PR TITLE
Update status to support blocked state

### DIFF
--- a/db/migrations/202110-fill-statuses.js
+++ b/db/migrations/202110-fill-statuses.js
@@ -1,0 +1,10 @@
+/**
+ * How to use this script to migrate elasticsearch schema
+ *  1. Start ssh port forwarding `ssh -L 62222:staging.server.path.to:62222 root@staging.server.path.to`
+ *  2. Add `ELASTICSEARCH_URL=http://localhost:62222` to .env
+ *  3. Reindex the following indexes using `npm run reindex`:
+ *     articlecategoryfeedbacks, articlereplyfeedbacks, replyrequests, users
+ *  4. Run `npx babel-node db/migrations/202110-fill-statuses.js`
+ */
+
+

--- a/db/migrations/202110-fill-statuses.js
+++ b/db/migrations/202110-fill-statuses.js
@@ -29,13 +29,21 @@ async function main() {
       index,
       type: 'doc',
       refresh: true,
-      conflicts: 'proceed',
       body: {
         script: {
           lang: 'painless',
           source: `
             ctx._source.status = 'NORMAL';
           `,
+        },
+        query: {
+          bool: {
+            must_not: {
+              exists: {
+                field: 'status',
+              },
+            },
+          },
         },
       },
     });

--- a/db/migrations/202110-fill-statuses.js
+++ b/db/migrations/202110-fill-statuses.js
@@ -2,9 +2,47 @@
  * How to use this script to migrate elasticsearch schema
  *  1. Start ssh port forwarding `ssh -L 62222:staging.server.path.to:62222 root@staging.server.path.to`
  *  2. Add `ELASTICSEARCH_URL=http://localhost:62222` to .env
- *  3. Reindex the following indexes using `npm run reindex`:
+ *  3. Reindex the following indexes using `npm run reload -- <index name>`:
  *     articlecategoryfeedbacks, articlereplyfeedbacks, replyrequests, users
  *  4. Run `npx babel-node db/migrations/202110-fill-statuses.js`
  */
 
+import 'dotenv/config';
+import '../../util/catchUnhandledRejection';
+import elasticsearch from '@elastic/elasticsearch';
 
+const client = new elasticsearch.Client({
+  node: process.env.ELASTICSEARCH_URL,
+});
+
+const INDEXES = [
+  'articlecategoryfeedbacks',
+  'articlereplyfeedbacks',
+  'replyrequests',
+];
+
+async function main() {
+  for (let index of INDEXES) {
+    console.log('Filling default status for index', index);
+    console.time(index);
+    const resp = await client.updateByQuery({
+      index,
+      type: 'doc',
+      refresh: true,
+      conflicts: 'proceed',
+      body: {
+        script: {
+          lang: 'painless',
+          source: `
+            ctx._source.status = 'NORMAL';
+          `,
+        },
+      },
+    });
+    console.timeEnd(index);
+    console.log(index, 'result', resp.body);
+    console.log('---------');
+  }
+}
+
+main().catch(console.error);

--- a/schema/articlecategoryfeedbacks.js
+++ b/schema/articlecategoryfeedbacks.js
@@ -1,4 +1,4 @@
-export const VERSION = '1.1.0';
+export const VERSION = '1.1.1';
 
 export default {
   properties: {
@@ -16,5 +16,7 @@ export default {
 
     createdAt: { type: 'date' },
     updatedAt: { type: 'date' },
+
+    status: { type: 'keyword' }, // NORMAL, BLOCKED
   },
 };

--- a/schema/articlereplyfeedbacks.js
+++ b/schema/articlereplyfeedbacks.js
@@ -1,4 +1,4 @@
-export const VERSION = '1.1.0';
+export const VERSION = '1.1.1';
 
 export default {
   properties: {
@@ -17,5 +17,7 @@ export default {
 
     createdAt: { type: 'date' },
     updatedAt: { type: 'date' },
+
+    status: { type: 'keyword' }, // NORMAL, BLOCKED
   },
 };

--- a/schema/articles.js
+++ b/schema/articles.js
@@ -47,7 +47,7 @@ export default {
         // Current reply type
         replyType: { type: 'keyword' },
 
-        status: { type: 'keyword' }, // NORMAL, DELETED
+        status: { type: 'keyword' }, // NORMAL, DELETED, BLOCKED
         createdAt: { type: 'date' },
         updatedAt: { type: 'date' },
       },
@@ -92,7 +92,7 @@ export default {
         // Foreign key
         categoryId: { type: 'keyword' },
 
-        status: { type: 'keyword' }, // NORMAL, DELETED
+        status: { type: 'keyword' }, // NORMAL, DELETED, BLOCKED
         createdAt: { type: 'date' },
         updatedAt: { type: 'date' },
       },

--- a/schema/replyrequests.js
+++ b/schema/replyrequests.js
@@ -1,4 +1,4 @@
-export const VERSION = '1.1.0';
+export const VERSION = '1.1.1';
 
 // A request from users for an article to be replied.
 // (articleId, userId, appId) should be unique throughout DB.
@@ -39,5 +39,7 @@ export default {
 
     createdAt: { type: 'date' },
     updatedAt: { type: 'date' },
+
+    status: { type: 'keyword' }, // NORMAL, BLOCKED
   },
 };

--- a/schema/users.js
+++ b/schema/users.js
@@ -1,4 +1,4 @@
-export const VERSION = '1.2.0';
+export const VERSION = '1.2.1';
 
 export default {
   properties: {
@@ -29,5 +29,9 @@ export default {
 
     // Timestamp for the last time the user performed a rumors-api API call
     lastActiveAt: { type: 'date' },
+
+    // URL to the announcement that blocks this user.
+    // If given, the user is blocked from submitting visible contents.
+    blockedReason: { type: 'keyword' },
   },
 };


### PR DESCRIPTION
## Spec
- Specification: https://g0v.hackmd.io/0Cv5hmmAQYyW8SJdXvfdtw#Delete-reply-requests---blocking-user-from-submitting-visible-contents
- Maps to milestone 1, schema changes: https://g0v.hackmd.io/rf0A7MRfTOC613QZmFehQA?both#1st-milestone-data-prep

## Changes

- add `status` field to `replyRequest`, `aritcleReplyFeedbacks` and `articleCategoryFeedbacks`
    - add migration script to populate the `status` field above
- Add `blockedReason` to `users`

## Migration steps

Times are calculated using production backup in 2021

### 1. Reload index for newly added fields
```bash
npm run reload -- articlecategoryfeedbacks # several seconds
npm run reload -- articlereplyfeedbacks # 2 mins
npm run reload -- replyrequests # 1 min
npm run reload -- users # 1 min
```

### 2. Update script
```
npx babel-node db/migrations/202110-fill-statuses.js
```