### PR TITLE
Attach status to articles to deal with SEO spam

### DIFF
--- a/schema/articles.js
+++ b/schema/articles.js
@@ -103,5 +103,7 @@ export default {
     // There will be an attachment describing the file when articleType is not TEXT
     attachmentUrl: { type: 'keyword' }, // URL stores the original file
     attachmentHash: { type: 'keyword' }, // hash (Perceptual Hash) for identifying two similar file
+
+    status: { type: 'keyword' }, // NORMAL, BLOCKED
   },
 };


### PR DESCRIPTION
Related discussion: https://g0v.hackmd.io/G8JKqoW6T-SpCa704awGsw#CIB-%E8%99%95%E7%90%86

Spammer's article type will be set to `DELETED`.
Articles with no `status` will be considered as `NORMAL`.