### PR TITLE
feat(airesponses): add ai response index

### DIFF
--- a/schema/airesponses.js
+++ b/schema/airesponses.js
@@ -7,7 +7,7 @@ export default {
     // the document ID for this response
     docId: { type: 'keyword' },
 
-    // article, or other types
+    // type of this AI response.
     type: { type: 'keyword' },
 
     // The user that requests an AI response
@@ -21,10 +21,10 @@ export default {
     // AI response text
     text: { type: 'text', analyzer: 'cjk_url_email' },
 
-    // The request to OpenAI. Just for record, not indexed.
+    // The request to AI endpoint. Just for record, not indexed.
     request: { type: 'keyword', index: false, doc_values: false },
 
-    // Token stats from OpenAI API.
+    // Token stats from AI endpoint response.
     usage: {
       type: 'object',
       properties: {

--- a/schema/airesponses.js
+++ b/schema/airesponses.js
@@ -1,0 +1,40 @@
+export const VERSION = '1.0.0';
+
+// A response from OpenAI.
+//
+export default {
+  properties: {
+    // the document ID for this response
+    docId: { type: 'keyword' },
+
+    // article, or other types
+    type: { type: 'keyword' },
+
+    // The user that requests an AI response
+    //
+    userId: { type: 'keyword' },
+    appId: { type: 'keyword' },
+
+    // LOADING | SUCCESS | ERROR
+    status: { type: 'keyword' },
+
+    // AI response text
+    text: { type: 'text', analyzer: 'cjk_url_email' },
+
+    // The request to OpenAI. Just for record, not indexed.
+    request: { type: 'keyword', index: false, doc_values: false },
+
+    // Token stats from OpenAI API.
+    usage: {
+      type: 'object',
+      properties: {
+        promptTokens: { type: 'long' },
+        completionTokens: { type: 'long' },
+        totalTokens: { type: 'long' },
+      },
+    },
+
+    createdAt: { type: 'date' },
+    updatedAt: { type: 'date' },
+  },
+};

--- a/schema/airesponses.js
+++ b/schema/airesponses.js
@@ -1,6 +1,6 @@
 export const VERSION = '1.0.0';
 
-// A response from OpenAI.
+// A response from AI. Can be AI reply, OCR, speech to text, etc.
 //
 export default {
   properties: {

--- a/schema/index.js
+++ b/schema/index.js
@@ -7,6 +7,7 @@ import { default as replies } from './replies';
 import { default as replyrequests } from './replyrequests';
 import { default as urls } from './urls';
 import { default as users } from './users';
+import { default as airesponses } from './airesponses';
 
 export {
   analytics,
@@ -18,4 +19,5 @@ export {
   replyrequests,
   urls,
   users,
+  airesponses,
 };


### PR DESCRIPTION
Design doc: https://github.blog/2023-03-23-we-updated-our-rsa-ssh-host-key/

Changes from design doc:
- `airesponses` only; move `airesponsefeedbacks` to when we are ready to implement feedbacks in the future
- `docType` --> `type`: this does not describe type of `docId`, but the type of the AI response itself.
    - `airesponses` index can support future AI responses such as OCR, speech to text, etc.
- `resolvedAt` --> `updatedAt`: match existing indexes' convention