### PR TITLE
Fix categories schema

### DIFF
--- a/schema/airesponses.ts
+++ b/schema/airesponses.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 
 import { dateSchema } from '../util/sharedSchema';
 
-export const VERSION = '1.0.0';
+export const VERSION = '1.0.1';
 
 export const schema = z.object({
   /** The document ID for this response */

--- a/schema/analytics.ts
+++ b/schema/analytics.ts
@@ -84,6 +84,7 @@ export const examples: Analytics[] = [
 ];
 
 export default {
+  dynamic: 'strict',
   properties: {
     date: { type: 'date' },
 

--- a/schema/analytics.ts
+++ b/schema/analytics.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 
 import { dateSchema } from '../util/sharedSchema';
 
-export const VERSION = '1.2.0';
+export const VERSION = '1.2.1';
 
 export const schema = z.object({
   date: dateSchema,

--- a/schema/articlecategoryfeedbacks.ts
+++ b/schema/articlecategoryfeedbacks.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { dateSchema } from '../util/sharedSchema';
 
-export const VERSION = '1.1.1';
+export const VERSION = '1.1.2';
 
 export const schema = z.object({
   articleId: z.string(),

--- a/schema/articlereplyfeedbacks.ts
+++ b/schema/articlereplyfeedbacks.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { dateSchema } from '../util/sharedSchema';
 
-export const VERSION = '1.2.0';
+export const VERSION = '1.2.1';
 
 export const schema = z.object({
   /** Target article-reply's article */

--- a/schema/articles.ts
+++ b/schema/articles.ts
@@ -336,6 +336,7 @@ export const examples: Article[] = [
 ];
 
 export default {
+  dynamic: 'strict',
   properties: {
     text: { type: 'text', analyzer: 'cjk_url_email' },
     createdAt: { type: 'date' },

--- a/schema/articles.ts
+++ b/schema/articles.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 
 import { dateSchema } from '../util/sharedSchema';
 
-export const VERSION = '1.4.0';
+export const VERSION = '1.4.1';
 
 export const schema = z.object({
   text: z.string(),

--- a/schema/articles.ts
+++ b/schema/articles.ts
@@ -124,6 +124,7 @@ export const schema = z.object({
       z.object({
         userId: z.string(),
         appId: z.string(),
+        /** last contribute time of the user */
         updatedAt: dateSchema,
       })
     )

--- a/schema/categories.ts
+++ b/schema/categories.ts
@@ -8,6 +8,10 @@ export const schema = z.object({
   description: z.string(),
   createdAt: dateSchema,
   updatedAt: dateSchema.optional(),
+
+  /** Populated by CreateCategory API */
+  userId: z.string().optional(),
+  appId: z.string().optional(),
 });
 
 export type Category = z.infer<typeof schema>;
@@ -29,5 +33,7 @@ export default {
     description: { type: 'text', analyzer: 'cjk' },
     createdAt: { type: 'date' },
     updatedAt: { type: 'date' },
+    userId: { type: 'keyword' },
+    appId: { type: 'keyword' },
   },
 };

--- a/schema/categories.ts
+++ b/schema/categories.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { dateSchema } from '../util/sharedSchema';
 
-export const VERSION = '1.1.0';
+export const VERSION = '1.1.1';
 
 export const schema = z.object({
   title: z.string(),

--- a/schema/cooccurrences.ts
+++ b/schema/cooccurrences.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { dateSchema } from '../util/sharedSchema';
 
-export const VERSION = '1.0.0';
+export const VERSION = '1.0.1';
 
 export const schema = z.object({
   createdAt: dateSchema,

--- a/schema/replies.ts
+++ b/schema/replies.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { dateSchema } from '../util/sharedSchema';
 
-export const VERSION = '1.1.0';
+export const VERSION = '1.1.1';
 
 export const schema = z.object({
   /** May be non-exist for very old sample replies */

--- a/schema/replyrequests.ts
+++ b/schema/replyrequests.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { dateSchema } from '../util/sharedSchema';
 
-export const VERSION = '1.1.1';
+export const VERSION = '1.1.2';
 
 /**
  * A request from users for an article to be replied.

--- a/schema/replyrequests.ts
+++ b/schema/replyrequests.ts
@@ -117,6 +117,7 @@ export const examples: ReplyRequest[] = [
 // (articleId, userId, appId) should be unique throughout DB.
 //
 export default {
+  dynamic: 'strict',
   properties: {
     articleId: { type: 'keyword' },
 

--- a/schema/urls.ts
+++ b/schema/urls.ts
@@ -79,6 +79,7 @@ export const examples: Url[] = [
 ];
 
 export default {
+  dynamic: 'strict',
   properties: {
     url: { type: 'keyword' },
     canonical: { type: 'keyword' },

--- a/schema/urls.ts
+++ b/schema/urls.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { dateSchema } from '../util/sharedSchema';
 
-export const VERSION = '1.1.0';
+export const VERSION = '1.1.1';
 
 /**
  * Schema definition for URLs.

--- a/schema/users.ts
+++ b/schema/users.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { dateSchema } from '../util/sharedSchema';
 
-export const VERSION = '1.2.1';
+export const VERSION = '1.2.2';
 
 export const schema = z
   .object({

--- a/schema/users.ts
+++ b/schema/users.ts
@@ -84,6 +84,7 @@ export const examples: User[] = [
 ];
 
 export default {
+  dynamic: 'strict',
   properties: {
     email: { type: 'keyword' },
     name: { type: 'keyword' },

--- a/schema/ydocs.ts
+++ b/schema/ydocs.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { dateSchema } from '../util/sharedSchema';
 
-export const VERSION = '1.0.1';
+export const VERSION = '1.0.2';
 
 /**
  * Defines the schema for ydocs.

--- a/schema/ydocs.ts
+++ b/schema/ydocs.ts
@@ -36,6 +36,7 @@ export const examples: YDoc[] = [
 ];
 
 export default {
+  dynamic: 'strict',
   properties: {
     ydoc: { type: 'binary' },
     versions: {


### PR DESCRIPTION
- Some newer categories created by CreateCategory actually have `userId` and `appId`
- rumors-api's `CreateCategory` test would fail without `userId` and `appId` explicitly defined
- Turn off dynamic field for all tables
    - Forgot to do so in previous PR
- Bump schema version to enable refresh