### PR TITLE
Fix scan by making zod schema strict

### DIFF
--- a/db/reloadSchema.js
+++ b/db/reloadSchema.js
@@ -137,4 +137,7 @@ async function main() {
   );
 }
 
-main().catch(console.error);
+main().catch((e) =>
+  // Complex errors if `meta` inside, try printing the whole object
+  'meta' in e ? console.error(JSON.stringify(e, null, '  ')) : console.error(e)
+);

--- a/db/scanIndex.ts
+++ b/db/scanIndex.ts
@@ -68,7 +68,7 @@ async function scanIndex(indexName: string) {
     }
 
     processedCount += 1;
-    if (processedCount % 1000 === 0) {
+    if (processedCount % 10000 === 0) {
       console.log(`Processed ${processedCount} / ${count}`);
     }
   }

--- a/db/scanIndex.ts
+++ b/db/scanIndex.ts
@@ -97,7 +97,11 @@ async function main() {
 }
 if (require.main === module) {
   main().catch((e) => {
-    console.error(e);
+    if ('meta' in e) {
+      console.error(JSON.stringify(e));
+    } else {
+      console.error(e);
+    }
     process.exit(1);
   });
 }

--- a/schema/airesponses.ts
+++ b/schema/airesponses.ts
@@ -31,6 +31,7 @@ export const schema = z
         completionTokens: z.number().optional(),
         totalTokens: z.number().optional(),
       })
+      .strict()
       .optional(),
 
     createdAt: dateSchema,

--- a/schema/airesponses.ts
+++ b/schema/airesponses.ts
@@ -4,37 +4,39 @@ import { dateSchema } from '../util/sharedSchema';
 
 export const VERSION = '1.0.1';
 
-export const schema = z.object({
-  /** The document ID for this response */
-  docId: z.string(),
+export const schema = z
+  .object({
+    /** The document ID for this response */
+    docId: z.string(),
 
-  /** type of this AI response. */
-  type: z.enum(['AI_REPLY', 'TRANSCRIPT']),
+    /** type of this AI response. */
+    type: z.enum(['AI_REPLY', 'TRANSCRIPT']),
 
-  /** The user that requests an AI response */
-  userId: z.string(),
-  appId: z.string(),
+    /** The user that requests an AI response */
+    userId: z.string(),
+    appId: z.string(),
 
-  status: z.enum(['LOADING', 'SUCCESS', 'ERROR']),
+    status: z.enum(['LOADING', 'SUCCESS', 'ERROR']),
 
-  /** AI response text */
-  text: z.string().optional(),
+    /** AI response text */
+    text: z.string().optional(),
 
-  /** The request to AI endpoint. Just for record, not indexed. */
-  request: z.string().optional(),
+    /** The request to AI endpoint. Just for record, not indexed. */
+    request: z.string().optional(),
 
-  /** Token stats from AI endpoint response */
-  usage: z
-    .object({
-      promptTokens: z.number().optional(),
-      completionTokens: z.number().optional(),
-      totalTokens: z.number().optional(),
-    })
-    .optional(),
+    /** Token stats from AI endpoint response */
+    usage: z
+      .object({
+        promptTokens: z.number().optional(),
+        completionTokens: z.number().optional(),
+        totalTokens: z.number().optional(),
+      })
+      .optional(),
 
-  createdAt: dateSchema,
-  updatedAt: dateSchema.optional(),
-});
+    createdAt: dateSchema,
+    updatedAt: dateSchema.optional(),
+  })
+  .strict();
 
 /**
  * A response from AI. Can be AI reply, OCR, speech to text, etc.

--- a/schema/analytics.ts
+++ b/schema/analytics.ts
@@ -4,41 +4,43 @@ import { dateSchema } from '../util/sharedSchema';
 
 export const VERSION = '1.2.1';
 
-export const schema = z.object({
-  date: dateSchema,
+export const schema = z
+  .object({
+    date: dateSchema,
 
-  /** article id or reply id */
-  docId: z.string(),
+    /** article id or reply id */
+    docId: z.string(),
 
-  // the timestamp for when the data is fetched
-  fetchedAt: dateSchema,
+    // the timestamp for when the data is fetched
+    fetchedAt: dateSchema,
 
-  stats: z.object({
-    lineUser: z.number().nullable().optional(),
-    lineVisit: z.number().nullable().optional(),
-    webUser: z.number().nullable().optional(),
-    webVisit: z.number().nullable().optional(),
+    stats: z.object({
+      lineUser: z.number().nullable().optional(),
+      lineVisit: z.number().nullable().optional(),
+      webUser: z.number().nullable().optional(),
+      webVisit: z.number().nullable().optional(),
 
-    /** LIFF traffic, breakdown by source  */
-    liff: z
-      .array(
-        z.object({
-          // Source can be '' or null if not specified
-          source: z.string().nullable(),
-          user: z.number(),
-          visit: z.number(),
-        })
-      )
-      .optional(),
-  }),
+      /** LIFF traffic, breakdown by source  */
+      liff: z
+        .array(
+          z.object({
+            // Source can be '' or null if not specified
+            source: z.string().nullable(),
+            user: z.number(),
+            visit: z.number(),
+          })
+        )
+        .optional(),
+    }),
 
-  type: z.enum(['article', 'reply']),
+    type: z.enum(['article', 'reply']),
 
-  /** May not exist or is null for old records */
-  docUserId: z.string().nullable().optional(),
-  /** May not exist or is null for old records */
-  docAppId: z.string().nullable().optional(),
-});
+    /** May not exist or is null for old records */
+    docUserId: z.string().nullable().optional(),
+    /** May not exist or is null for old records */
+    docAppId: z.string().nullable().optional(),
+  })
+  .strict();
 
 export type Analytics = z.infer<typeof schema>;
 

--- a/schema/analytics.ts
+++ b/schema/analytics.ts
@@ -14,24 +14,28 @@ export const schema = z
     // the timestamp for when the data is fetched
     fetchedAt: dateSchema,
 
-    stats: z.object({
-      lineUser: z.number().nullable().optional(),
-      lineVisit: z.number().nullable().optional(),
-      webUser: z.number().nullable().optional(),
-      webVisit: z.number().nullable().optional(),
+    stats: z
+      .object({
+        lineUser: z.number().nullable().optional(),
+        lineVisit: z.number().nullable().optional(),
+        webUser: z.number().nullable().optional(),
+        webVisit: z.number().nullable().optional(),
 
-      /** LIFF traffic, breakdown by source  */
-      liff: z
-        .array(
-          z.object({
-            // Source can be '' or null if not specified
-            source: z.string().nullable(),
-            user: z.number(),
-            visit: z.number(),
-          })
-        )
-        .optional(),
-    }),
+        /** LIFF traffic, breakdown by source  */
+        liff: z
+          .array(
+            z
+              .object({
+                // Source can be '' or null if not specified
+                source: z.string().nullable(),
+                user: z.number(),
+                visit: z.number(),
+              })
+              .strict()
+          )
+          .optional(),
+      })
+      .strict(),
 
     type: z.enum(['article', 'reply']),
 

--- a/schema/articlecategoryfeedbacks.ts
+++ b/schema/articlecategoryfeedbacks.ts
@@ -3,19 +3,21 @@ import { dateSchema } from '../util/sharedSchema';
 
 export const VERSION = '1.1.2';
 
-export const schema = z.object({
-  articleId: z.string(),
-  categoryId: z.string(),
-  userId: z.string(),
-  /** The user submits the feedback with which client. */
-  appId: z.string(),
-  score: z.number().int().min(-1).max(1),
-  /** user comment for the article category */
-  comment: z.string().optional(),
-  createdAt: dateSchema,
-  updatedAt: dateSchema.optional(),
-  status: z.enum(['NORMAL', 'BLOCKED']),
-});
+export const schema = z
+  .object({
+    articleId: z.string(),
+    categoryId: z.string(),
+    userId: z.string(),
+    /** The user submits the feedback with which client. */
+    appId: z.string(),
+    score: z.number().int().min(-1).max(1),
+    /** user comment for the article category */
+    comment: z.string().optional(),
+    createdAt: dateSchema,
+    updatedAt: dateSchema.optional(),
+    status: z.enum(['NORMAL', 'BLOCKED']),
+  })
+  .strict();
 
 export type ArticleCategoryFeedback = z.infer<typeof schema>;
 

--- a/schema/articlereplyfeedbacks.ts
+++ b/schema/articlereplyfeedbacks.ts
@@ -3,29 +3,31 @@ import { dateSchema } from '../util/sharedSchema';
 
 export const VERSION = '1.2.1';
 
-export const schema = z.object({
-  /** Target article-reply's article */
-  articleId: z.string(),
-  /** Target article-reply's reply */
-  replyId: z.string(),
+export const schema = z
+  .object({
+    /** Target article-reply's article */
+    articleId: z.string(),
+    /** Target article-reply's reply */
+    replyId: z.string(),
 
-  /** `users` index ID for the author of the feedback */
-  userId: z.string(),
+    /** `users` index ID for the author of the feedback */
+    userId: z.string(),
 
-  /** The user submits the feedback with which client. */
-  appId: z.string(),
+    /** The user submits the feedback with which client. */
+    appId: z.string(),
 
-  /** `users` index ID for the author of the reply. May not exist for older doucments */
-  replyUserId: z.string().optional(),
+    /** `users` index ID for the author of the reply. May not exist for older doucments */
+    replyUserId: z.string().optional(),
 
-  /** `users` index ID for the author of the article-reply. May not exist for older doucments */
-  articleReplyUserId: z.string().optional(),
-  score: z.number().int().min(-1).max(1),
-  comment: z.string().nullable().optional(),
-  createdAt: dateSchema,
-  updatedAt: dateSchema.optional(),
-  status: z.enum(['NORMAL', 'BLOCKED']),
-});
+    /** `users` index ID for the author of the article-reply. May not exist for older doucments */
+    articleReplyUserId: z.string().optional(),
+    score: z.number().int().min(-1).max(1),
+    comment: z.string().nullable().optional(),
+    createdAt: dateSchema,
+    updatedAt: dateSchema.optional(),
+    status: z.enum(['NORMAL', 'BLOCKED']),
+  })
+  .strict();
 
 export type ArticleReplyFeedback = z.infer<typeof schema>;
 

--- a/schema/articles.ts
+++ b/schema/articles.ts
@@ -21,39 +21,43 @@ export const schema = z
      * "references" field should be a list of such occurrences.
      */
     references: z.array(
-      z.object({
-        type: z.string(), // LINE, URL, etc
-        permalink: z.string().optional(), // permalink to the resource if applicable
-        createdAt: dateSchema.optional().nullable(),
+      z
+        .object({
+          type: z.string(), // LINE, URL, etc
+          permalink: z.string().optional(), // permalink to the resource if applicable
+          createdAt: dateSchema.optional().nullable(),
 
-        // auth
-        userId: z.string().optional(),
-        appId: z.string().optional(),
-      })
+          // auth
+          userId: z.string().optional(),
+          appId: z.string().optional(),
+        })
+        .strict()
     ),
 
     /** Linkage between articles and replies */
     articleReplies: z.array(
-      z.object({
-        /** Who connected the replyId with the article. */
-        userId: z.string(),
-        appId: z.string(),
+      z
+        .object({
+          /** Who connected the replyId with the article. */
+          userId: z.string(),
+          appId: z.string(),
 
-        /** Counter cache for feedbacks */
-        positiveFeedbackCount: z.number(),
-        negativeFeedbackCount: z.number(),
+          /** Counter cache for feedbacks */
+          positiveFeedbackCount: z.number(),
+          negativeFeedbackCount: z.number(),
 
-        /** One reply can have multiple articlereplies. */
-        replyId: z.string(),
+          /** One reply can have multiple articlereplies. */
+          replyId: z.string(),
 
-        /** Current reply type */
-        replyType: z.string(),
+          /** Current reply type */
+          replyType: z.string(),
 
-        status: z.enum(['NORMAL', 'DELETED', 'BLOCKED']),
-        /** Can be null for very old replies */
-        createdAt: dateSchema.nullable(),
-        updatedAt: dateSchema.optional().nullable(),
-      })
+          status: z.enum(['NORMAL', 'DELETED', 'BLOCKED']),
+          /** Can be null for very old replies */
+          createdAt: dateSchema.nullable(),
+          updatedAt: dateSchema.optional().nullable(),
+        })
+        .strict()
     ),
 
     /**
@@ -70,44 +74,48 @@ export const schema = z
     /** Links in article text */
     hyperlinks: z
       .array(
-        z.object({
-          /** exact URL found in the articles */
-          url: z.string(),
+        z
+          .object({
+            /** exact URL found in the articles */
+            url: z.string(),
 
-          /** URL after normalization (stored in urls) */
-          normalizedUrl: z.string().optional(),
-          title: z.string().nullable(),
+            /** URL after normalization (stored in urls) */
+            normalizedUrl: z.string().optional(),
+            title: z.string().nullable(),
 
-          /** Extracted summary text */
-          summary: z.string().optional().nullable(),
-        })
+            /** Extracted summary text */
+            summary: z.string().optional().nullable(),
+          })
+          .strict()
       )
       .optional(),
 
     articleCategories: z.array(
-      z.object({
-        /**
-         * Who created the category
-         * Empty if the category is added by AI
-         */
-        userId: z.string().optional(),
-        appId: z.string().optional(),
+      z
+        .object({
+          /**
+           * Who created the category
+           * Empty if the category is added by AI
+           */
+          userId: z.string().optional(),
+          appId: z.string().optional(),
 
-        /** exists only for AI tags */
-        aiModel: z.string().optional(),
-        aiConfidence: z.number().optional(),
+          /** exists only for AI tags */
+          aiModel: z.string().optional(),
+          aiConfidence: z.number().optional(),
 
-        /** Counter cache for feedbacks */
-        positiveFeedbackCount: z.number(),
-        negativeFeedbackCount: z.number(),
+          /** Counter cache for feedbacks */
+          positiveFeedbackCount: z.number(),
+          negativeFeedbackCount: z.number(),
 
-        /** Foreign key */
-        categoryId: z.string(),
+          /** Foreign key */
+          categoryId: z.string(),
 
-        status: z.enum(['NORMAL', 'DELETED', 'BLOCKED']),
-        createdAt: dateSchema,
-        updatedAt: dateSchema.optional(),
-      })
+          status: z.enum(['NORMAL', 'DELETED', 'BLOCKED']),
+          createdAt: dateSchema,
+          updatedAt: dateSchema.optional(),
+        })
+        .strict()
     ),
 
     articleType: z.enum(['TEXT', 'IMAGE', 'VIDEO', 'AUDIO']),
@@ -122,12 +130,14 @@ export const schema = z
     /** transcript contributors */
     contributors: z
       .array(
-        z.object({
-          userId: z.string(),
-          appId: z.string(),
-          /** last contribute time of the user */
-          updatedAt: dateSchema,
-        })
+        z
+          .object({
+            userId: z.string(),
+            appId: z.string(),
+            /** last contribute time of the user */
+            updatedAt: dateSchema,
+          })
+          .strict()
       )
       .optional(),
   })

--- a/schema/articles.ts
+++ b/schema/articles.ts
@@ -4,132 +4,134 @@ import { dateSchema } from '../util/sharedSchema';
 
 export const VERSION = '1.4.1';
 
-export const schema = z.object({
-  text: z.string(),
-  // Can be null for very old sample messages
-  createdAt: dateSchema.nullable(),
-  updatedAt: dateSchema.optional().nullable(),
+export const schema = z
+  .object({
+    text: z.string(),
+    // Can be null for very old sample messages
+    createdAt: dateSchema.nullable(),
+    updatedAt: dateSchema.optional().nullable(),
 
-  /** User who submitted the article */
-  userId: z.string(),
-  appId: z.string(),
+    /** User who submitted the article */
+    userId: z.string(),
+    appId: z.string(),
 
-  /**
-   * Where this article is posted.
-   * An article may be seen in multiple places, like blogs, FB posts or LINE messages.
-   * "references" field should be a list of such occurrences.
-   */
-  references: z.array(
-    z.object({
-      type: z.string(), // LINE, URL, etc
-      permalink: z.string().optional(), // permalink to the resource if applicable
-      createdAt: dateSchema.optional().nullable(),
-
-      // auth
-      userId: z.string().optional(),
-      appId: z.string().optional(),
-    })
-  ),
-
-  /** Linkage between articles and replies */
-  articleReplies: z.array(
-    z.object({
-      /** Who connected the replyId with the article. */
-      userId: z.string(),
-      appId: z.string(),
-
-      /** Counter cache for feedbacks */
-      positiveFeedbackCount: z.number(),
-      negativeFeedbackCount: z.number(),
-
-      /** One reply can have multiple articlereplies. */
-      replyId: z.string(),
-
-      /** Current reply type */
-      replyType: z.string(),
-
-      status: z.enum(['NORMAL', 'DELETED', 'BLOCKED']),
-      /** Can be null for very old replies */
-      createdAt: dateSchema.nullable(),
-      updatedAt: dateSchema.optional().nullable(),
-    })
-  ),
-
-  /**
-   * Cached counts of articleReplies with status = NORMAL.
-   * The length of nested objects cannot be used in filters...
-   */
-  normalArticleReplyCount: z.number(),
-  normalArticleCategoryCount: z.number(),
-
-  /** Cached counter and timestamp from replyrequests */
-  replyRequestCount: z.number(),
-  lastRequestedAt: dateSchema.nullable().optional(),
-
-  /** Links in article text */
-  hyperlinks: z
-    .array(
+    /**
+     * Where this article is posted.
+     * An article may be seen in multiple places, like blogs, FB posts or LINE messages.
+     * "references" field should be a list of such occurrences.
+     */
+    references: z.array(
       z.object({
-        /** exact URL found in the articles */
-        url: z.string(),
+        type: z.string(), // LINE, URL, etc
+        permalink: z.string().optional(), // permalink to the resource if applicable
+        createdAt: dateSchema.optional().nullable(),
 
-        /** URL after normalization (stored in urls) */
-        normalizedUrl: z.string().optional(),
-        title: z.string().nullable(),
-
-        /** Extracted summary text */
-        summary: z.string().optional().nullable(),
+        // auth
+        userId: z.string().optional(),
+        appId: z.string().optional(),
       })
-    )
-    .optional(),
+    ),
 
-  articleCategories: z.array(
-    z.object({
-      /**
-       * Who created the category
-       * Empty if the category is added by AI
-       */
-      userId: z.string().optional(),
-      appId: z.string().optional(),
-
-      /** exists only for AI tags */
-      aiModel: z.string().optional(),
-      aiConfidence: z.number().optional(),
-
-      /** Counter cache for feedbacks */
-      positiveFeedbackCount: z.number(),
-      negativeFeedbackCount: z.number(),
-
-      /** Foreign key */
-      categoryId: z.string(),
-
-      status: z.enum(['NORMAL', 'DELETED', 'BLOCKED']),
-      createdAt: dateSchema,
-      updatedAt: dateSchema.optional(),
-    })
-  ),
-
-  articleType: z.enum(['TEXT', 'IMAGE', 'VIDEO', 'AUDIO']),
-
-  /** There will be an attachment describing the file when articleType is not TEXT */
-  attachmentUrl: z.string().optional(),
-  /** hash (Perceptual Hash) for identifying two similar file */
-  attachmentHash: z.string().optional(),
-
-  status: z.enum(['NORMAL', 'BLOCKED']),
-
-  /** transcript contributors */
-  contributors: z
-    .array(
+    /** Linkage between articles and replies */
+    articleReplies: z.array(
       z.object({
+        /** Who connected the replyId with the article. */
         userId: z.string(),
         appId: z.string(),
-        /** last contribute time of the user */
-        updatedAt: dateSchema,
+
+        /** Counter cache for feedbacks */
+        positiveFeedbackCount: z.number(),
+        negativeFeedbackCount: z.number(),
+
+        /** One reply can have multiple articlereplies. */
+        replyId: z.string(),
+
+        /** Current reply type */
+        replyType: z.string(),
+
+        status: z.enum(['NORMAL', 'DELETED', 'BLOCKED']),
+        /** Can be null for very old replies */
+        createdAt: dateSchema.nullable(),
+        updatedAt: dateSchema.optional().nullable(),
       })
-    )
-    .optional(),
-});
+    ),
+
+    /**
+     * Cached counts of articleReplies with status = NORMAL.
+     * The length of nested objects cannot be used in filters...
+     */
+    normalArticleReplyCount: z.number(),
+    normalArticleCategoryCount: z.number(),
+
+    /** Cached counter and timestamp from replyrequests */
+    replyRequestCount: z.number(),
+    lastRequestedAt: dateSchema.nullable().optional(),
+
+    /** Links in article text */
+    hyperlinks: z
+      .array(
+        z.object({
+          /** exact URL found in the articles */
+          url: z.string(),
+
+          /** URL after normalization (stored in urls) */
+          normalizedUrl: z.string().optional(),
+          title: z.string().nullable(),
+
+          /** Extracted summary text */
+          summary: z.string().optional().nullable(),
+        })
+      )
+      .optional(),
+
+    articleCategories: z.array(
+      z.object({
+        /**
+         * Who created the category
+         * Empty if the category is added by AI
+         */
+        userId: z.string().optional(),
+        appId: z.string().optional(),
+
+        /** exists only for AI tags */
+        aiModel: z.string().optional(),
+        aiConfidence: z.number().optional(),
+
+        /** Counter cache for feedbacks */
+        positiveFeedbackCount: z.number(),
+        negativeFeedbackCount: z.number(),
+
+        /** Foreign key */
+        categoryId: z.string(),
+
+        status: z.enum(['NORMAL', 'DELETED', 'BLOCKED']),
+        createdAt: dateSchema,
+        updatedAt: dateSchema.optional(),
+      })
+    ),
+
+    articleType: z.enum(['TEXT', 'IMAGE', 'VIDEO', 'AUDIO']),
+
+    /** There will be an attachment describing the file when articleType is not TEXT */
+    attachmentUrl: z.string().optional(),
+    /** hash (Perceptual Hash) for identifying two similar file */
+    attachmentHash: z.string().optional(),
+
+    status: z.enum(['NORMAL', 'BLOCKED']),
+
+    /** transcript contributors */
+    contributors: z
+      .array(
+        z.object({
+          userId: z.string(),
+          appId: z.string(),
+          /** last contribute time of the user */
+          updatedAt: dateSchema,
+        })
+      )
+      .optional(),
+  })
+  .strict();
 
 export type Article = z.infer<typeof schema>;
 export type ArticleReply = Article['articleReplies'][number];

--- a/schema/categories.ts
+++ b/schema/categories.ts
@@ -3,16 +3,18 @@ import { dateSchema } from '../util/sharedSchema';
 
 export const VERSION = '1.1.1';
 
-export const schema = z.object({
-  title: z.string(),
-  description: z.string(),
-  createdAt: dateSchema,
-  updatedAt: dateSchema.optional(),
+export const schema = z
+  .object({
+    title: z.string(),
+    description: z.string(),
+    createdAt: dateSchema,
+    updatedAt: dateSchema.optional(),
 
-  /** Populated by CreateCategory API */
-  userId: z.string().optional(),
-  appId: z.string().optional(),
-});
+    /** Populated by CreateCategory API */
+    userId: z.string().optional(),
+    appId: z.string().optional(),
+  })
+  .strict();
 
 export type Category = z.infer<typeof schema>;
 

--- a/schema/cooccurrences.ts
+++ b/schema/cooccurrences.ts
@@ -3,19 +3,21 @@ import { dateSchema } from '../util/sharedSchema';
 
 export const VERSION = '1.0.1';
 
-export const schema = z.object({
-  createdAt: dateSchema,
+export const schema = z
+  .object({
+    createdAt: dateSchema,
 
-  /** Last date the same user reported this combination of articles */
-  updatedAt: dateSchema.optional(),
+    /** Last date the same user reported this combination of articles */
+    updatedAt: dateSchema.optional(),
 
-  /** Who reported this cooccurrence */
-  userId: z.string(),
-  appId: z.string(),
+    /** Who reported this cooccurrence */
+    userId: z.string(),
+    appId: z.string(),
 
-  /** The articles */
-  articleIds: z.array(z.string()),
-});
+    /** The articles */
+    articleIds: z.array(z.string()),
+  })
+  .strict();
 
 export type Cooccurrence = z.infer<typeof schema>;
 

--- a/schema/replies.ts
+++ b/schema/replies.ts
@@ -17,17 +17,19 @@ export const schema = z
     /** Links in article text */
     hyperlinks: z
       .array(
-        z.object({
-          /** exact URL found in the articles */
-          url: z.string(),
+        z
+          .object({
+            /** exact URL found in the articles */
+            url: z.string(),
 
-          /** URL after normalization (stored in urls) */
-          normalizedUrl: z.string().optional(),
-          title: z.string().nullable(),
+            /** URL after normalization (stored in urls) */
+            normalizedUrl: z.string().optional(),
+            title: z.string().nullable(),
 
-          /** Extracted summary text */
-          summary: z.string().optional().nullable(),
-        })
+            /** Extracted summary text */
+            summary: z.string().optional().nullable(),
+          })
+          .strict()
       )
       .optional(),
   })

--- a/schema/replies.ts
+++ b/schema/replies.ts
@@ -3,33 +3,35 @@ import { dateSchema } from '../util/sharedSchema';
 
 export const VERSION = '1.1.1';
 
-export const schema = z.object({
-  /** May be non-exist for very old sample replies */
-  userId: z.string().nullable().optional(),
-  appId: z.string().nullable(),
-  type: z.enum(['RUMOR', 'NOT_RUMOR', 'OPINIONATED', 'NOT_ARTICLE']),
-  text: z.string(),
-  reference: z.string().optional(),
+export const schema = z
+  .object({
+    /** May be non-exist for very old sample replies */
+    userId: z.string().nullable().optional(),
+    appId: z.string().nullable(),
+    type: z.enum(['RUMOR', 'NOT_RUMOR', 'OPINIONATED', 'NOT_ARTICLE']),
+    text: z.string(),
+    reference: z.string().optional(),
 
-  /** May be non-exist for very old sample replies */
-  createdAt: dateSchema.nullable(),
-  /** Links in article text */
-  hyperlinks: z
-    .array(
-      z.object({
-        /** exact URL found in the articles */
-        url: z.string(),
+    /** May be non-exist for very old sample replies */
+    createdAt: dateSchema.nullable(),
+    /** Links in article text */
+    hyperlinks: z
+      .array(
+        z.object({
+          /** exact URL found in the articles */
+          url: z.string(),
 
-        /** URL after normalization (stored in urls) */
-        normalizedUrl: z.string().optional(),
-        title: z.string().nullable(),
+          /** URL after normalization (stored in urls) */
+          normalizedUrl: z.string().optional(),
+          title: z.string().nullable(),
 
-        /** Extracted summary text */
-        summary: z.string().optional().nullable(),
-      })
-    )
-    .optional(),
-});
+          /** Extracted summary text */
+          summary: z.string().optional().nullable(),
+        })
+      )
+      .optional(),
+  })
+  .strict();
 
 export type Reply = z.infer<typeof schema>;
 

--- a/schema/replyrequests.ts
+++ b/schema/replyrequests.ts
@@ -36,20 +36,22 @@ export const schema = z
      */
     feedbacks: z
       .array(
-        z.object({
-          /**
-           * Auth
-           */
-          userId: z.string(),
-          appId: z.string(),
+        z
+          .object({
+            /**
+             * Auth
+             */
+            userId: z.string(),
+            appId: z.string(),
 
-          /**
-           * The score of the feedback. Should be 1, 0, or -1.
-           */
-          score: z.number().int().min(-1).max(1),
-          createdAt: dateSchema,
-          updatedAt: dateSchema,
-        })
+            /**
+             * The score of the feedback. Should be 1, 0, or -1.
+             */
+            score: z.number().int().min(-1).max(1),
+            createdAt: dateSchema,
+            updatedAt: dateSchema,
+          })
+          .strict()
       )
       .optional(),
 

--- a/schema/replyrequests.ts
+++ b/schema/replyrequests.ts
@@ -7,65 +7,67 @@ export const VERSION = '1.1.2';
  * A request from users for an article to be replied.
  * (articleId, userId, appId) should be unique throughout DB.
  */
-export const schema = z.object({
-  /**
-   * The article ID and user ID is used in calculating replyrequests' ID.
-   */
-  articleId: z.string(),
+export const schema = z
+  .object({
+    /**
+     * The article ID and user ID is used in calculating replyrequests' ID.
+     */
+    articleId: z.string(),
 
-  /**
-   * Auth
-   * only recognizable for within a client.
-   */
-  userId: z.string(),
+    /**
+     * Auth
+     * only recognizable for within a client.
+     */
+    userId: z.string(),
 
-  /**
-   * The user submits the request with which client.
-   * Should be one of backend APP ID, 'BOT_LEGACY', 'RUMORS_LINE_BOT' or 'WEBSITE'
-   */
-  appId: z.string(),
+    /**
+     * The user submits the request with which client.
+     * Should be one of backend APP ID, 'BOT_LEGACY', 'RUMORS_LINE_BOT' or 'WEBSITE'
+     */
+    appId: z.string(),
 
-  /**
-   * Why the ReplyRequest is created
-   */
-  reason: z.string().optional(),
+    /**
+     * Why the ReplyRequest is created
+     */
+    reason: z.string().optional(),
 
-  /**
-   * Editor's feedbacks for the reply request's reason
-   */
-  feedbacks: z
-    .array(
-      z.object({
-        /**
-         * Auth
-         */
-        userId: z.string(),
-        appId: z.string(),
+    /**
+     * Editor's feedbacks for the reply request's reason
+     */
+    feedbacks: z
+      .array(
+        z.object({
+          /**
+           * Auth
+           */
+          userId: z.string(),
+          appId: z.string(),
 
-        /**
-         * The score of the feedback. Should be 1, 0, or -1.
-         */
-        score: z.number().int().min(-1).max(1),
-        createdAt: dateSchema,
-        updatedAt: dateSchema,
-      })
-    )
-    .optional(),
+          /**
+           * The score of the feedback. Should be 1, 0, or -1.
+           */
+          score: z.number().int().min(-1).max(1),
+          createdAt: dateSchema,
+          updatedAt: dateSchema,
+        })
+      )
+      .optional(),
 
-  /**
-   * Counter cache for feedbacks
-   */
-  positiveFeedbackCount: z.number().int().optional(),
-  negativeFeedbackCount: z.number().int().optional(),
+    /**
+     * Counter cache for feedbacks
+     */
+    positiveFeedbackCount: z.number().int().optional(),
+    negativeFeedbackCount: z.number().int().optional(),
 
-  /**
-   * The creation date of the reply request.
-   */
-  createdAt: dateSchema.nullable(),
-  updatedAt: dateSchema.optional(),
+    /**
+     * The creation date of the reply request.
+     */
+    createdAt: dateSchema.nullable(),
+    updatedAt: dateSchema.optional(),
 
-  status: z.enum(['NORMAL', 'BLOCKED']),
-});
+    status: z.enum(['NORMAL', 'BLOCKED']),
+  })
+  .strict();
 
 export type ReplyRequest = z.infer<typeof schema>;
 

--- a/schema/urls.ts
+++ b/schema/urls.ts
@@ -6,48 +6,50 @@ export const VERSION = '1.1.1';
 /**
  * Schema definition for URLs.
  */
-export const schema = z.object({
-  /**
-   * Exact URL found in the articles.
-   */
-  url: z.string(),
-  /**
-   * The canonical URL fetched from the page.
-   */
-  canonical: z.string(),
-  /**
-   * Title of the page.
-   */
-  title: z.string(),
-  /**
-   * Extracted summary text.
-   */
-  summary: z.string(),
-  /**
-   * Fetched raw html input. Can be very long.
-   */
-  html: z.string(),
-  /**
-   * Image URL for preview. It could be a base64 string, which can be too long.
-   */
-  topImageUrl: z.string().optional(),
-  /**
-   * The date and time the URL was fetched.
-   */
-  fetchedAt: dateSchema,
-  /**
-   * Status code of the response.
-   */
-  status: z.number().int(),
-  /**
-   * Error returned by cofacts-url-resolver.
-   */
-  error: z.string().optional(),
-  /**
-   * rumors-api cleanupUrls.js script flag field.
-   */
-  isReferenced: z.boolean().optional(),
-});
+export const schema = z
+  .object({
+    /**
+     * Exact URL found in the articles.
+     */
+    url: z.string(),
+    /**
+     * The canonical URL fetched from the page.
+     */
+    canonical: z.string(),
+    /**
+     * Title of the page.
+     */
+    title: z.string(),
+    /**
+     * Extracted summary text.
+     */
+    summary: z.string(),
+    /**
+     * Fetched raw html input. Can be very long.
+     */
+    html: z.string(),
+    /**
+     * Image URL for preview. It could be a base64 string, which can be too long.
+     */
+    topImageUrl: z.string().optional(),
+    /**
+     * The date and time the URL was fetched.
+     */
+    fetchedAt: dateSchema,
+    /**
+     * Status code of the response.
+     */
+    status: z.number().int(),
+    /**
+     * Error returned by cofacts-url-resolver.
+     */
+    error: z.string().optional(),
+    /**
+     * rumors-api cleanupUrls.js script flag field.
+     */
+    isReferenced: z.boolean().optional(),
+  })
+  .strict();
 
 export type Url = z.infer<typeof schema>;
 

--- a/schema/users.ts
+++ b/schema/users.ts
@@ -31,6 +31,15 @@ export const schema = z
      * If given, the user is blocked from submitting visible contents.
      */
     blockedReason: z.string().optional(),
+
+    // Optional fields, more restrictions below
+    appId: z.string().optional(),
+    appUserId: z.string().optional(),
+    facebookId: z.string().optional(),
+    githubId: z.string().optional(),
+    twitterId: z.string().optional(),
+    googleId: z.string().optional(),
+    instagramId: z.string().optional(),
   })
   .strict()
   .and(
@@ -38,8 +47,8 @@ export const schema = z
     z.union([
       /** Provided for apps other than websites */
       z.object({
-        appId: z.string().optional(),
-        appUserId: z.string().optional(),
+        appId: z.string(),
+        appUserId: z.string(),
       }),
       /** Social login for web users */
       z.union([

--- a/schema/users.ts
+++ b/schema/users.ts
@@ -32,6 +32,7 @@ export const schema = z
      */
     blockedReason: z.string().optional(),
   })
+  .strict()
   .and(
     /** Auth related IDs */
     z.union([

--- a/schema/ydocs.ts
+++ b/schema/ydocs.ts
@@ -6,20 +6,22 @@ export const VERSION = '1.0.2';
 /**
  * Defines the schema for ydocs.
  */
-export const schema = z.object({
-  /** Represents the ydoc in binary format. */
-  ydoc: z.string(),
-  versions: z
-    .array(
-      z.object({
-        /** Snapshot of the ydoc in binary format. */
-        snapshot: z.string(),
-        /** The creation date of the snapshot. */
-        createdAt: dateSchema,
-      })
-    )
-    .optional(),
-});
+export const schema = z
+  .object({
+    /** Represents the ydoc in binary format. */
+    ydoc: z.string(),
+    versions: z
+      .array(
+        z.object({
+          /** Snapshot of the ydoc in binary format. */
+          snapshot: z.string(),
+          /** The creation date of the snapshot. */
+          createdAt: dateSchema,
+        })
+      )
+      .optional(),
+  })
+  .strict();
 
 export type YDoc = z.infer<typeof schema>;
 

--- a/schema/ydocs.ts
+++ b/schema/ydocs.ts
@@ -12,12 +12,14 @@ export const schema = z
     ydoc: z.string(),
     versions: z
       .array(
-        z.object({
-          /** Snapshot of the ydoc in binary format. */
-          snapshot: z.string(),
-          /** The creation date of the snapshot. */
-          createdAt: dateSchema,
-        })
+        z
+          .object({
+            /** Snapshot of the ydoc in binary format. */
+            snapshot: z.string(),
+            /** The creation date of the snapshot. */
+            createdAt: dateSchema,
+          })
+          .strict()
       )
       .optional(),
   })


### PR DESCRIPTION
`npm run scan` omits extra fields by default, while Elasticsearch with strict mapping settings rejects such documents.

This PR adds `strict()` to all Zod schemas, so that `npm run scan` can also pick up documents with extra fields.

This PR also improves error reporting by printing deeply nested objects.