### PR TITLE
fix(schema): relax urls field

### DIFF
--- a/schema/urls.ts
+++ b/schema/urls.ts
@@ -15,23 +15,23 @@ export const schema = z
     /**
      * The canonical URL fetched from the page.
      */
-    canonical: z.string(),
+    canonical: z.string().nullable(),
     /**
      * Title of the page.
      */
-    title: z.string(),
+    title: z.string().nullable(),
     /**
      * Extracted summary text.
      */
-    summary: z.string(),
+    summary: z.string().nullable(),
     /**
      * Fetched raw html input. Can be very long.
      */
-    html: z.string(),
+    html: z.string().nullable(),
     /**
      * Image URL for preview. It could be a base64 string, which can be too long.
      */
-    topImageUrl: z.string().optional(),
+    topImageUrl: z.string().optional().nullable(),
     /**
      * The date and time the URL was fetched.
      */
@@ -39,11 +39,11 @@ export const schema = z
     /**
      * Status code of the response.
      */
-    status: z.number().int(),
+    status: z.number().int().nullable(),
     /**
      * Error returned by cofacts-url-resolver.
      */
-    error: z.string().optional(),
+    error: z.string().optional().nullable(),
     /**
      * rumors-api cleanupUrls.js script flag field.
      */


### PR DESCRIPTION
 because we can't control url-resolver result being null or undefined.